### PR TITLE
feat: relax require-await rule

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -149,7 +149,7 @@ module.exports = {
         // Enforce the consistent use of the radix argument when using parseInt()
         'radix': 2,
         // Disallow async functions which have no await expression
-        'require-await': 2,
+        'require-await': 0,
         // Require var declarations be placed at the top of their containing scope
         'vars-on-top': 2,
         // Require parentheses around immediate function invocations

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -383,12 +383,6 @@ Array [
     "rule": "no-return-await",
     "severity": 2,
   },
-  Object {
-    "column": 5,
-    "line": 22,
-    "rule": "require-await",
-    "severity": 2,
-  },
 ]
 `;
 

--- a/test/fixtures/rules/best-practices/es8/best-practices.js
+++ b/test/fixtures/rules/best-practices/es8/best-practices.js
@@ -17,15 +17,9 @@
 
 // `require-await` - disallow async functions which have no await expression
 // ---------------------------------------------------------------------
-// Bad
+// Not active
 (function () {
     async function foo() {
         console.log('foo');
-    }
-})();
-// Good
-(function () {
-    async function foo() {
-        await Promise.resolve();
     }
 })();


### PR DESCRIPTION
Reasoning: sometimes you want to have a promise returning function that actually uses only sync stuff inside. In those situations, using `async` is a lot cleaner than having to use Promise.resolve & Promise.reject.