### PR TITLE
feat: allow require for configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then enhance it with one or more **addons**:
 
 - `browser` - If you are going to develop code for the browser (assumes you use CommonJS or AMD)
 - `node` - If you are going to develop code for [NodeJS](nodejs.org)
-- `es-modules`: If you are going to use ES6 import & export instead of CommonJS or AMD
+- `es-modules`: If you are going to use ES6 import & export instead of CommonJS or AMD (this rule skips root `[...].config.js` files to avoid ignoring this rule in common configuration files)
 - `babel-parser`: Use [babel-eslint](https://github.com/babel/babel-eslint) parser so that you may use language features that are not yet implemented in eslint (e.g.: dynamic imports)
 - `react` - If you are going to use [React](https://reactjs.org/) (requires `es6` base configuration or higher)
 - `jest` - If you are going to use [Jest](https://facebook.github.io/jest/) to develop tests

--- a/addons/es-modules.js
+++ b/addons/es-modules.js
@@ -15,4 +15,10 @@ module.exports = {
         // comment: This should be a warning instead of an error because there are still cases when we must use require.
         'prefer-import/prefer-import-over-require': 1,
     },
+    "overrides": [{
+        'files': '**/*.config.js',
+        'rules': {
+            'prefer-import/prefer-import-over-require': 0
+        },
+    }],
 };

--- a/addons/es-modules.js
+++ b/addons/es-modules.js
@@ -15,10 +15,10 @@ module.exports = {
         // comment: This should be a warning instead of an error because there are still cases when we must use require.
         'prefer-import/prefer-import-over-require': 1,
     },
-    "overrides": [{
-        'files': '**/*.config.js',
+    'overrides': [{
+        'files': '*.config.js',
         'rules': {
-            'prefer-import/prefer-import-over-require': 0
+            'prefer-import/prefer-import-over-require': 0,
         },
     }],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -3675,7 +3675,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3696,12 +3697,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3716,17 +3719,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3843,7 +3849,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3855,6 +3862,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3869,6 +3877,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3876,12 +3885,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3900,6 +3911,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3980,7 +3992,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3992,6 +4005,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4077,7 +4091,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4113,6 +4128,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4132,6 +4148,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4175,12 +4192,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1769,6 +1769,19 @@ Array [
 
 exports[`should pass on fixtures/samples/es6-modules/contrived.good.js 1`] = `Array []`;
 
+exports[`should pass on fixtures/samples/es6-modules/require.config.js 1`] = `Array []`;
+
+exports[`should pass on fixtures/samples/es6-modules/require.js 1`] = `
+Array [
+  Object {
+    "column": 14,
+    "line": 5,
+    "rule": "prefer-import/prefer-import-over-require",
+    "severity": 1,
+  },
+]
+`;
+
 exports[`should pass on fixtures/samples/es6-node/fileSize.good.js 1`] = `Array []`;
 
 exports[`should pass on fixtures/samples/es6-node/loudException.good.js 1`] = `Array []`;

--- a/test/fixtures/samples/es6-modules/require.config.js
+++ b/test/fixtures/samples/es6-modules/require.config.js
@@ -1,0 +1,7 @@
+// Made up sample.. not genuine
+
+// [...].config.js file, should not warn against require
+
+const test = require('good');
+
+console.log(test);

--- a/test/fixtures/samples/es6-modules/require.js
+++ b/test/fixtures/samples/es6-modules/require.js
@@ -1,0 +1,7 @@
+// Made up sample.. not genuine
+
+// Common file, should warn against require
+
+const test = require('bad');
+
+console.log(test);


### PR DESCRIPTION
With this PR linting skips `prefer import` rules for `.config.js` files, root or nested.

This removes the need to manually ignore these rules on common configuration files.