### PR TITLE
chore: set checkLocalVariables to true on jsx-handler-names rules

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -2237,7 +2237,16 @@ exports[`should pass on packages/eslint-config-react/test/samples/my-component/M
 
 exports[`should pass on packages/eslint-config-react/test/samples/my-component/MyComponent.old.js 1`] = `Array []`;
 
-exports[`should pass on packages/eslint-config-react/test/samples/my-component/MyComponent.test.js 1`] = `Array []`;
+exports[`should pass on packages/eslint-config-react/test/samples/my-component/MyComponent.test.js 1`] = `
+Array [
+  Object {
+    "column": 43,
+    "line": 4,
+    "rule": "react/jsx-handler-names",
+    "severity": 2,
+  },
+]
+`;
 
 exports[`should pass on packages/eslint-config-react-web-a11y/test/rules/jsx-a11y.js 1`] = `
 Array [

--- a/packages/eslint-config-react/lib/rules/react.js
+++ b/packages/eslint-config-react/lib/rules/react.js
@@ -24,6 +24,7 @@ module.exports = {
         'react/jsx-handler-names': ['error', {
             eventHandlerPrefix: 'handle',
             eventHandlerPropPrefix: 'on',
+            checkLocalVariables: true,
         }],
         // Validate props indentation in JSX
         'react/jsx-indent-props': ['error', 4],


### PR DESCRIPTION
This is to ensure that all event handlers are properly named, according to the rules specified.