### PR TITLE
feat: add import order rules

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1318,20 +1318,68 @@ exports[`should pass on packages/eslint-config-base/test/samples/es2015-esm/cont
 Array [
   Object {
     "column": 1,
-    "line": 5,
+    "line": 4,
     "rule": "strict",
     "severity": 2,
   },
   Object {
-    "column": 13,
+    "column": 1,
+    "line": 8,
+    "rule": "import/order",
+    "severity": 2,
+  },
+  Object {
+    "column": 8,
+    "line": 8,
+    "rule": "no-unused-vars",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
     "line": 9,
+    "rule": "import/order",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "line": 11,
+    "rule": "import/order",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "line": 12,
+    "rule": "import/newline-after-import",
+    "severity": 2,
+  },
+  Object {
+    "column": 13,
+    "line": 21,
     "rule": "import/no-commonjs",
     "severity": 2,
   },
   Object {
     "column": 13,
-    "line": 9,
+    "line": 21,
+    "rule": "import/order",
+    "severity": 2,
+  },
+  Object {
+    "column": 13,
+    "line": 21,
     "rule": "no-undef",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "line": 24,
+    "rule": "import/first",
+    "severity": 2,
+  },
+  Object {
+    "column": 8,
+    "line": 24,
+    "rule": "no-unused-vars",
     "severity": 2,
   },
 ]
@@ -2757,6 +2805,12 @@ Array [
 
 exports[`should pass on packages/eslint-config-vue/test/rules/vue-no-shared-component-data.vue 1`] = `
 Array [
+  Object {
+    "column": 1,
+    "line": 5,
+    "rule": "import/newline-after-import",
+    "severity": 2,
+  },
   Object {
     "column": 5,
     "line": 7,

--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1329,12 +1329,6 @@ Array [
     "severity": 2,
   },
   Object {
-    "column": 8,
-    "line": 8,
-    "rule": "no-unused-vars",
-    "severity": 2,
-  },
-  Object {
     "column": 1,
     "line": 9,
     "rule": "import/order",
@@ -1354,32 +1348,26 @@ Array [
   },
   Object {
     "column": 13,
-    "line": 21,
+    "line": 22,
     "rule": "import/no-commonjs",
     "severity": 2,
   },
   Object {
     "column": 13,
-    "line": 21,
+    "line": 22,
     "rule": "import/order",
     "severity": 2,
   },
   Object {
     "column": 13,
-    "line": 21,
+    "line": 22,
     "rule": "no-undef",
     "severity": 2,
   },
   Object {
     "column": 1,
-    "line": 24,
+    "line": 25,
     "rule": "import/first",
-    "severity": 2,
-  },
-  Object {
-    "column": 8,
-    "line": 24,
-    "rule": "no-unused-vars",
     "severity": 2,
   },
 ]
@@ -2806,14 +2794,8 @@ Array [
 exports[`should pass on packages/eslint-config-vue/test/rules/vue-no-shared-component-data.vue 1`] = `
 Array [
   Object {
-    "column": 1,
-    "line": 5,
-    "rule": "import/newline-after-import",
-    "severity": 2,
-  },
-  Object {
     "column": 5,
-    "line": 7,
+    "line": 8,
     "rule": "vue/no-shared-component-data",
     "severity": 2,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,25 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+			"integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
+			"requires": {
+				"browserslist": "^4.9.1",
+				"invariant": "^2.2.4",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
 			}
 		},
 		"@babel/core": {
@@ -53,7 +69,6 @@
 			"version": "7.8.8",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
 			"integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.7",
 				"jsesc": "^2.5.1",
@@ -64,16 +79,135 @@
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
+			}
+		},
+		"@babel/helper-annotate-as-pure": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+			"integrity": "sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+			"integrity": "sha512-5eFOm2SyFPK4Rh3XMMRDjN7lBH0orh3ss0g3rTYZnBQ+r6YPj7lgDyCvPphynHvUrobJmeMignBr6Acw9mAPlw==",
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.9.0.tgz",
+			"integrity": "sha512-weiIo4gaoGgnhff54GQ3P5wsUQmnSwpkvU0r6ZHq6TzoSzKy4JxHEgnxNytaKbov2a9z/CVNyzliuCOUPEX3Jw==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/types": "^7.9.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.0",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-builder-react-jsx-experimental": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.9.0.tgz",
+			"integrity": "sha512-3xJEiyuYU4Q/Ar9BsHisgdxZsRlsShMe90URZ0e6przL26CCs8NJbDoxH94kKT17PcxlMhsCAwZd90evCo26VQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/types": "^7.9.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.0",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.8.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+			"integrity": "sha512-4mWm8DCK2LugIS+p1yArqvG1Pf162upsIsjE7cNBjez+NjliQpVhj20obE520nao0o14DaTnFJv+Fw5a0JpoUw==",
+			"requires": {
+				"@babel/compat-data": "^7.8.6",
+				"browserslist": "^4.9.1",
+				"invariant": "^2.2.4",
+				"levenary": "^1.1.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.6.tgz",
+			"integrity": "sha512-klTBDdsr+VFFqaDHm5rR69OpEQtO2Qv8ECxHS1mNhJJvaHArR6a1xTf5K/eZW7eZpJbhCx3NW1Yt/sKsLXLblg==",
+			"requires": {
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-split-export-declaration": "^7.8.3"
+			}
+		},
+		"@babel/helper-create-regexp-features-plugin": {
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+			"integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-regex": "^7.8.3",
+				"regexpu-core": "^4.7.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+			"integrity": "sha512-PoeBYtxoZGtct3md6xZOCWPcKuMuk3IHhgxsRRNtnNShebf4C8YonTSblsK4tvDbm+eJAw2HAPOfCr+Q/YRG/g==",
+			"requires": {
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/types": "^7.8.3",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+			"integrity": "sha512-N+8eW86/Kj147bO9G2uclsg5pwfs/fqqY5rwgIL7eTBklgXjcOJ3btzS5iM6AitJcftnY7pm2lGsrJVYLGjzIw==",
+			"requires": {
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
 			}
 		},
 		"@babel/helper-function-name": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
 			"integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -84,7 +218,64 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"dev": true,
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+			"integrity": "sha512-ky1JLOjcDUtSc+xkt0xhYff7Z6ILTAHKmZLHPxAhOP0Nd77O+3nCsd6uSVYur6nJnCI029CrNbYlc0LoPfAPQg==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.9.0",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.0",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -92,15 +283,69 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-			"dev": true
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+		},
+		"@babel/helper-regex": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+			"integrity": "sha512-BWt0QtYv/cg/NecOAZMdcn/waj/5P26DR4mVLXfFtDokSR6fyuG0Pj+e2FqtSME+MqED1khnSMulkmGl8qWiUQ==",
+			"requires": {
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-remap-async-to-generator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-kgwDmw4fCg7AVgS4DukQR/roGp+jP+XluJE5hsRZwxCYGg+Rv9wSGErDWhlI90FODdYfd4xG4AQRiMDjjN0GzA==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-wrap-function": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
 		},
 		"@babel/helper-split-export-declaration": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"dev": true,
 			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+			"integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw=="
+		},
+		"@babel/helper-wrap-function": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+			"integrity": "sha512-LACJrbUET9cQDzb6kG7EeD7+7doC3JNvUgTEQOx2qaO1fKlzE/Bf05qs9w1oXQMmXlPO65lC3Tq9S6gZpTErEQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.8.3",
 				"@babel/types": "^7.8.3"
 			}
 		},
@@ -119,7 +364,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
 			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
@@ -129,8 +373,106 @@
 		"@babel/parser": {
 			"version": "7.8.8",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-			"integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
-			"dev": true
+			"integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA=="
+		},
+		"@babel/plugin-proposal-async-generator-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+			"integrity": "sha512-NZ9zLv848JsV3hs8ryEh7Uaz/0KsmPLqv0+PdkDJL1cJy0K4kOCFa8zc1E3mp+RHPQcpdfb/6GovEsW4VDrOMw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-class-properties": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.8.3.tgz",
+			"integrity": "sha512-EqFhbo7IosdgPgZggHaNObkmO1kNUe3slaKu54d5OWvy+p9QIKOzK1GAEpAIsZtWVtPXUHSMcT4smvDrCfY4AA==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-NyaBbyLFXFLT9FP+zk0kYlUlA8XtCUbehs67F0nnEg7KICgMc2mNkIeu9TYhKzyXMkrapZFwAhXLdnt4IYHy1w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+			"integrity": "sha512-KGhQNZ3TVCQG/MjRbAUwuH+14y9q0tpxs1nWWs3pbSleRdDro9SAMMDyye8HhY1gqZ7/NqIc8SKhya0wRDgP1Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+			"integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.3"
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
+			"integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-0gkX7J7E+AtAw9fcwlVQj8peP61qhdg/89D5swOkjYbkboA2CVckn3kiyum1DE0wskGb7KJJxBdyEBApDLLVdw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+			"integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+			"integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.8",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-async-generators": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+			"integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
 		},
 		"@babel/plugin-syntax-bigint": {
 			"version": "7.8.3",
@@ -141,20 +483,515 @@
 				"@babel/helper-plugin-utils": "^7.8.0"
 			}
 		},
+		"@babel/plugin-syntax-dynamic-import": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+			"integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz",
+			"integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+			"integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+			"integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
 			"integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-catch-binding": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+			"integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+			"integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+			"integrity": "sha512-0MRF+KC8EqH4dbuITCWwPSzsyO3HIWWlm30v8BbbpOrS1B++isGxPnnuq/IZvOX5J2D/p7DQalQm+/2PnlKGxg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+			"integrity": "sha512-imt9tFLD9ogt56Dd5CI/6XgpukMwd/fLGSrix2httihVe7LOGVPhyhMh1BU5kDM7iHD08i8uUtmV2sWaBFlHVQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-remap-async-to-generator": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+			"integrity": "sha512-vo4F2OewqjbB1+yaJ7k2EJFHlTP3jR634Z9Cj9itpqNjuLXvhlVxgnjsHsdRgASR8xYDrx6onw4vW5H6We0Jmg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+			"integrity": "sha512-pGnYfm7RNRgYRi7bids5bHluENHqJhrV4bCZRwc5GamaWIIs07N4rZECcmJL6ZClwjDz1GbdMZFtPs27hTB06w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.2.tgz",
+			"integrity": "sha512-TC2p3bPzsfvSsqBZo0kJnuelnoK9O3welkUpqSqBQuBF6R5MN2rysopri8kNvtlGIb2jmUO7i15IooAZJjZuMQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-define-map": "^7.8.3",
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+			"integrity": "sha512-O5hiIpSyOGdrQZRQ2ccwtTVkgUDBBiCuK//4RJ6UfePllUTCENOzKxfh6ulckXKc0DixTFLCfb2HVkNA7aDpzA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.8.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
+			"integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-dotall-regex": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+			"integrity": "sha512-kLs1j9Nn4MQoBYdRXH6AeaXMbEJFaFu/v1nQkvib6QzTj8MZI5OQzqmD83/2jEM1z0DLilra5aWO5YpyC0ALIw==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+			"integrity": "sha512-s8dHiBUbcbSgipS4SMFuWGqCvyge5V2ZeAWzR6INTVC3Ltjig/Vw1G2Gztv0vU/hRG9X8IvKvYdoksnUfgXOEQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+			"integrity": "sha512-zwIpuIymb3ACcInbksHaNcR12S++0MDLKkiqXHl3AzpgdKlFNhog+z/K0+TGW+b0w5pgTq4H6IwV/WhxbGYSjQ==",
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+			"integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+			"integrity": "sha512-rO/OnDS78Eifbjn5Py9v8y0aR+aSYhDhqAwVfsTl0ERuMZyr05L1aFSCJnbv2mmsLkit/4ReeQ9N2BgLnOcPCQ==",
+			"requires": {
+				"@babel/helper-function-name": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+			"integrity": "sha512-3Tqf8JJ/qB7TeldGl+TT55+uQei9JfYaregDcEAyBZ7akutriFrt6C/wLYIer6OYhleVQvH/ntEhjE/xMmy10A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+			"integrity": "sha512-3Wk2EXhnw+rP+IDkK6BdtPKsUE5IeZ6QOGrPYvw52NwBStw9V1ZVzxgK6fSKSxqUvH9eQPR3tm3cOq79HlsKYA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+			"integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-commonjs": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+			"integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-simple-access": "^7.8.3",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+			"integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.8.3",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+			"integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
+			"requires": {
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+			"integrity": "sha512-f+tF/8UVPU86TrCb06JoPWIdDpTNSGGcAtaD9mLP0aYGA0OS0j7j7DHJR0GTFrUZPUU6loZhbsVZgTh0N+Qdnw==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+			"integrity": "sha512-QuSGysibQpyxexRyui2vca+Cmbljo8bcRckgzYV4kRIsHpVeyeC3JDO63pY+xFZ6bWOBn7pfKZTqV4o/ix9sFw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+			"integrity": "sha512-57FXk+gItG/GejofIyLIgBKTas4+pEU47IXKDBWFTxdPd7F80H8zybyAY7UoblVfBhBGs2EKM+bJUu2+iUYPDQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.9.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.3.tgz",
+			"integrity": "sha512-fzrQFQhp7mIhOzmOtPiKffvCYQSK10NR8t6BBz2yPbeUHb9OLW8RZGtgDRBn8z2hGcwvKDL3vC7ojPTLNxmqEg==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+			"integrity": "sha512-uGiiXAZMqEoQhRWMK17VospMZh5sXWg+dlh2soffpkAl96KAm+WZuJfa6lcELotSRmooLqg0MWdH6UUq85nmmg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.3.tgz",
+			"integrity": "sha512-3Jy/PCw8Fe6uBKtEgz3M82ljt+lTg+xJaM4og+eyu83qLT87ZUSckn0wy7r31jflURWLO83TW6Ylf7lyXj3m5A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.9.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.9.4.tgz",
+			"integrity": "sha512-Mjqf3pZBNLt854CK0C/kRuXAnE6H/bo7xYojP+WGtX8glDGSibcwnsWwhwoSuRg0+EBnxPC1ouVnuetUIlPSAw==",
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.9.0",
+				"@babel/helper-builder-react-jsx-experimental": "^7.9.0",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-self": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.9.0.tgz",
+			"integrity": "sha512-K2ObbWPKT7KUTAoyjCsFilOkEgMvFG+y0FqOl6Lezd0/13kMkkjHskVsZvblRPj1PHA44PrToaZANrryppzTvQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.9.0.tgz",
+			"integrity": "sha512-K6m3LlSnTSfRkM6FcRk8saNEeaeyG5k7AVkBU2bZK3+1zdkSED3qNdsWrUgQBeTVD2Tp3VMmerxVO2yM5iITmw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.8.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
+			"integrity": "sha512-TIg+gAl4Z0a3WmD3mbYSk+J9ZUH6n/Yc57rtKRnlA/7rcCvpekHXe0CMZHP1gYp7/KLe9GHTuIba0vXmls6drA==",
+			"requires": {
+				"regenerator-transform": "^0.14.2"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+			"integrity": "sha512-mwMxcycN3omKFDjDQUl+8zyMsBfjRFr0Zn/64I41pmjv4NJuqcYlEtezwYtw9TFd9WR1vN5kiM+O0gMZzO6L0A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
+			"integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+			"integrity": "sha512-I9DI6Odg0JJwxCHzbzW08ggMdCezoWcuQRz3ptdudgwaHxTjxw5HgdFJmZIkIMlRymL6YiZcped4TTCB0JcC8w==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+			"integrity": "sha512-CkuTU9mbmAoFOI1tklFWYYbzX5qCIZVXPVy0jpXgGwkplCndQAa58s2jr66fTeQnA64bDox0HL4U56CFYoyC7g==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+			"integrity": "sha512-9Spq0vGCD5Bb4Z/ZXXSK5wbbLFMG085qd2vhL1JYu1WcQ5bXqZBAYRzU1d+p79GcHs2szYv5pVQCX13QgldaWw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/helper-regex": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+			"integrity": "sha512-820QBtykIQOLFT8NZOcTRJ1UNuztIELe4p9DCgvj4NK+PwluSJ49we7s9FB1HIGNIYT7wFUJ0ar2QpCDj0escQ==",
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+			"integrity": "sha512-2QKyfjGdvuNfHsb7qnBBlKclbD4CfshH2KvDabiijLMGXPHJXGxtDzwIF7bQP+T0ysw8fYTtxPafgfs/c1Lrqg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+			"integrity": "sha512-+ufgJjYdmWfSQ+6NS9VGUR2ns8cjJjYbrbi11mZBTaWm+Fui/ncTLFF28Ei1okavY+xkojGr1eJxNsWYeA5aZw==",
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
+			"integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
+			"requires": {
+				"@babel/compat-data": "^7.9.0",
+				"@babel/helper-compilation-targets": "^7.8.7",
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
+				"@babel/plugin-proposal-json-strings": "^7.8.3",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-proposal-numeric-separator": "^7.8.3",
+				"@babel/plugin-proposal-object-rest-spread": "^7.9.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.8.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.8.3",
+				"@babel/plugin-transform-arrow-functions": "^7.8.3",
+				"@babel/plugin-transform-async-to-generator": "^7.8.3",
+				"@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+				"@babel/plugin-transform-block-scoping": "^7.8.3",
+				"@babel/plugin-transform-classes": "^7.9.0",
+				"@babel/plugin-transform-computed-properties": "^7.8.3",
+				"@babel/plugin-transform-destructuring": "^7.8.3",
+				"@babel/plugin-transform-dotall-regex": "^7.8.3",
+				"@babel/plugin-transform-duplicate-keys": "^7.8.3",
+				"@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+				"@babel/plugin-transform-for-of": "^7.9.0",
+				"@babel/plugin-transform-function-name": "^7.8.3",
+				"@babel/plugin-transform-literals": "^7.8.3",
+				"@babel/plugin-transform-member-expression-literals": "^7.8.3",
+				"@babel/plugin-transform-modules-amd": "^7.9.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.9.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.9.0",
+				"@babel/plugin-transform-modules-umd": "^7.9.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+				"@babel/plugin-transform-new-target": "^7.8.3",
+				"@babel/plugin-transform-object-super": "^7.8.3",
+				"@babel/plugin-transform-parameters": "^7.8.7",
+				"@babel/plugin-transform-property-literals": "^7.8.3",
+				"@babel/plugin-transform-regenerator": "^7.8.7",
+				"@babel/plugin-transform-reserved-words": "^7.8.3",
+				"@babel/plugin-transform-shorthand-properties": "^7.8.3",
+				"@babel/plugin-transform-spread": "^7.8.3",
+				"@babel/plugin-transform-sticky-regex": "^7.8.3",
+				"@babel/plugin-transform-template-literals": "^7.8.3",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.4",
+				"@babel/plugin-transform-unicode-regex": "^7.8.3",
+				"@babel/preset-modules": "^0.1.3",
+				"@babel/types": "^7.9.0",
+				"browserslist": "^4.9.1",
+				"core-js-compat": "^3.6.2",
+				"invariant": "^2.2.2",
+				"levenary": "^1.1.1",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.9.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+					"integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.0",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/preset-modules": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+			"integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+				"@babel/plugin-transform-dotall-regex": "^7.4.4",
+				"@babel/types": "^7.4.4",
+				"esutils": "^2.0.2"
 			}
 		},
 		"@babel/runtime": {
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
 			"integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			},
@@ -162,8 +999,23 @@
 				"regenerator-runtime": {
 					"version": "0.13.5",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-					"dev": true
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+				}
+			}
+		},
+		"@babel/runtime-corejs3": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+			"integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
+			"requires": {
+				"core-js-pure": "^3.0.0",
+				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.5",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+					"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 				}
 			}
 		},
@@ -171,7 +1023,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -182,7 +1033,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
 			"integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.8.6",
@@ -198,8 +1048,7 @@
 				"globals": {
 					"version": "11.12.0",
 					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 				}
 			}
 		},
@@ -207,7 +1056,6 @@
 			"version": "7.8.7",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
 			"integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
-			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.13",
@@ -2320,6 +3168,30 @@
 				"rimraf": "^2.5.2"
 			}
 		},
+		"@moxy/babel-preset": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/@moxy/babel-preset/-/babel-preset-3.2.5.tgz",
+			"integrity": "sha512-TJauG+t1sQs0tObzGh4dovobP6/kHczu2InFSvHNH2WuMvIB/DP8DIlikEFdd8ANG8Nu/8z6mynXQUlDKJ9pww==",
+			"requires": {
+				"@babel/plugin-proposal-class-properties": "^7.8.3",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-proposal-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+				"@babel/plugin-syntax-jsx": "^7.8.3",
+				"@babel/plugin-transform-react-display-name": "^7.8.3",
+				"@babel/plugin-transform-react-jsx": "^7.8.3",
+				"@babel/plugin-transform-react-jsx-self": "^7.8.3",
+				"@babel/plugin-transform-react-jsx-source": "^7.8.3",
+				"@babel/plugin-transform-runtime": "^7.8.3",
+				"@babel/preset-env": "^7.8.3",
+				"@babel/runtime": "^7.8.3",
+				"babel-plugin-add-module-exports": "^1.0.2",
+				"babel-plugin-dynamic-import-node": "^2.3.0",
+				"babel-plugin-lodash": "^3.3.4",
+				"babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+				"browserslist-config-google": "^2.0.0"
+			}
+		},
 		"@moxy/jest-config": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/@moxy/jest-config/-/jest-config-2.1.0.tgz",
@@ -2729,6 +3601,11 @@
 				"pretty-format": "^25.1.0"
 			}
 		},
+		"@types/json-schema": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+			"integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA=="
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2777,6 +3654,49 @@
 			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
 			"dev": true
 		},
+		"@typescript-eslint/experimental-utils": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz",
+			"integrity": "sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==",
+			"requires": {
+				"@types/json-schema": "^7.0.3",
+				"@typescript-eslint/typescript-estree": "2.25.0",
+				"eslint-scope": "^5.0.0",
+				"eslint-utils": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-utils": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+					"integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
+					}
+				}
+			}
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz",
+			"integrity": "sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-visitor-keys": "^1.1.0",
+				"glob": "^7.1.6",
+				"is-glob": "^4.0.1",
+				"lodash": "^4.17.15",
+				"semver": "^6.3.0",
+				"tsutils": "^3.17.1"
+			}
+		},
+		"@vue/eslint-config-prettier": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
+			"integrity": "sha512-wFQmv45c3ige5EA+ngijq40YpVcIkAy0Lihupnsnd1Dao5CBbPyfCzqtejFLZX1EwH/kCJdpz3t6s+5wd3+KxQ==",
+			"requires": {
+				"eslint-config-prettier": "^6.0.0"
+			}
+		},
 		"@zkochan/cmd-shim": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
@@ -2813,8 +3733,7 @@
 		"acorn": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-			"dev": true
+			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
 		},
 		"acorn-globals": {
 			"version": "4.3.4",
@@ -2837,8 +3756,7 @@
 		"acorn-jsx": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
-			"dev": true
+			"integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
 		},
 		"acorn-walk": {
 			"version": "6.2.0",
@@ -2903,7 +3821,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -2955,23 +3872,29 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
+			}
+		},
 		"arr-diff": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-			"dev": true
+			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"arr-union": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-			"dev": true
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
 			"version": "2.1.0",
@@ -3003,6 +3926,16 @@
 			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
 			"dev": true
 		},
+		"array-includes": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.1.tgz",
+			"integrity": "sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"is-string": "^1.0.5"
+			}
+		},
 		"array-union": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -3021,8 +3954,7 @@
 		"array-unique": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-			"dev": true
+			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.flat": {
 			"version": "1.2.3",
@@ -3043,8 +3975,7 @@
 		"asap": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-			"dev": true
+			"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
 		},
 		"asn1": {
 			"version": "0.2.4",
@@ -3064,14 +3995,24 @@
 		"assign-symbols": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-			"dev": true
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
 			"dev": true
+		},
+		"async-each": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+			"optional": true
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -3082,8 +4023,7 @@
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"dev": true
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
 		"atob-lite": {
 			"version": "2.0.0",
@@ -3102,6 +4042,24 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
+		},
+		"axobject-query": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+			"integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ=="
+		},
+		"babel-eslint": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+			"integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"@babel/parser": "^7.7.0",
+				"@babel/traverse": "^7.7.0",
+				"@babel/types": "^7.7.0",
+				"eslint-visitor-keys": "^1.0.0",
+				"resolve": "^1.12.0"
+			}
 		},
 		"babel-jest": {
 			"version": "25.1.0",
@@ -3170,6 +4128,22 @@
 				}
 			}
 		},
+		"babel-plugin-add-module-exports": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.2.tgz",
+			"integrity": "sha512-4paN7RivvU3Rzju1vGSHWPjO8Y0rI6droWvSFKI6dvEQ4mvoV0zGojnlzVRfI6N8zISo6VERXt3coIuVmzuvNg==",
+			"requires": {
+				"chokidar": "^2.0.4"
+			}
+		},
+		"babel-plugin-dynamic-import-node": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+			"integrity": "sha512-o6qFkpeQEBxcqt0XYlWzAVxNCSCZdUgcR8IRlhD/8DylxjjO4foPcvTW0GGKa/cVt3rvxZ7o5ippJ+/0nvLhlQ==",
+			"requires": {
+				"object.assign": "^4.1.0"
+			}
+		},
 		"babel-plugin-istanbul": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -3191,6 +4165,23 @@
 			"requires": {
 				"@types/babel__traverse": "^7.0.6"
 			}
+		},
+		"babel-plugin-lodash": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-lodash/-/babel-plugin-lodash-3.3.4.tgz",
+			"integrity": "sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0-beta.49",
+				"@babel/types": "^7.0.0-beta.49",
+				"glob": "^7.1.1",
+				"lodash": "^4.17.10",
+				"require-package-name": "^2.0.1"
+			}
+		},
+		"babel-plugin-transform-react-remove-prop-types": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
+			"integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
 		},
 		"babel-polyfill": {
 			"version": "6.26.0",
@@ -3235,14 +4226,12 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-			"dev": true
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
 		"base": {
 			"version": "0.11.2",
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"dev": true,
 			"requires": {
 				"cache-base": "^1.0.1",
 				"class-utils": "^0.3.5",
@@ -3257,7 +4246,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -3266,7 +4254,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3275,7 +4262,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -3284,7 +4270,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -3308,6 +4293,21 @@
 			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
 			"dev": true
 		},
+		"binary-extensions": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+			"optional": true
+		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"optional": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3324,7 +4324,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3361,6 +4360,22 @@
 					"dev": true
 				}
 			}
+		},
+		"browserslist": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
+			"integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001035",
+				"electron-to-chromium": "^1.3.380",
+				"node-releases": "^1.1.52",
+				"pkg-up": "^3.1.0"
+			}
+		},
+		"browserslist-config-google": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/browserslist-config-google/-/browserslist-config-google-2.0.0.tgz",
+			"integrity": "sha512-kfSzwT0sSkLquGpMLe//wK5zgyMBEs3Nf1N4BnFNHoY34g7BNGQbontOF/Yoi6Xs3Swai3sTOycKn1yOP5N+ng=="
 		},
 		"bser": {
 			"version": "2.1.1",
@@ -3428,7 +4443,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"dev": true,
 			"requires": {
 				"collection-visit": "^1.0.0",
 				"component-emitter": "^1.2.1",
@@ -3496,6 +4510,11 @@
 				"quick-lru": "^1.0.0"
 			}
 		},
+		"caniuse-lite": {
+			"version": "1.0.30001038",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+			"integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ=="
+		},
 		"capture-exit": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
@@ -3515,7 +4534,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -3553,6 +4571,657 @@
 				}
 			}
 		},
+		"chokidar": {
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+			"optional": true,
+			"requires": {
+				"anymatch": "^2.0.0",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
+				"glob-parent": "^3.1.0",
+				"inherits": "^2.0.3",
+				"is-binary-path": "^1.0.0",
+				"is-glob": "^4.0.0",
+				"normalize-path": "^3.0.0",
+				"path-is-absolute": "^1.0.0",
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			},
+			"dependencies": {
+				"anymatch": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+					"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+					"optional": true,
+					"requires": {
+						"micromatch": "^3.1.4",
+						"normalize-path": "^2.1.1"
+					},
+					"dependencies": {
+						"normalize-path": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+							"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+							"optional": true,
+							"requires": {
+								"remove-trailing-separator": "^1.0.1"
+							}
+						}
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"optional": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"optional": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fsevents": {
+					"version": "1.2.12",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+					"integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+					"optional": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"nan": "^2.12.1",
+						"node-pre-gyp": "*"
+					},
+					"dependencies": {
+						"abbrev": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"ansi-regex": {
+							"version": "2.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						},
+						"are-we-there-yet": {
+							"version": "1.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^2.0.6"
+							}
+						},
+						"balanced-match": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"brace-expansion": {
+							"version": "1.1.11",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"balanced-match": "^1.0.0",
+								"concat-map": "0.0.1"
+							}
+						},
+						"chownr": {
+							"version": "1.1.4",
+							"bundled": true,
+							"optional": true
+						},
+						"code-point-at": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"concat-map": {
+							"version": "0.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"console-control-strings": {
+							"version": "1.1.0",
+							"bundled": true,
+							"optional": true
+						},
+						"core-util-is": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"debug": {
+							"version": "3.2.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ms": "^2.1.1"
+							}
+						},
+						"deep-extend": {
+							"version": "0.6.0",
+							"bundled": true,
+							"optional": true
+						},
+						"delegates": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"detect-libc": {
+							"version": "1.0.3",
+							"bundled": true,
+							"optional": true
+						},
+						"fs-minipass": {
+							"version": "1.2.7",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.6.0"
+							}
+						},
+						"fs.realpath": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"gauge": {
+							"version": "2.7.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"aproba": "^1.0.3",
+								"console-control-strings": "^1.0.0",
+								"has-unicode": "^2.0.0",
+								"object-assign": "^4.1.0",
+								"signal-exit": "^3.0.0",
+								"string-width": "^1.0.1",
+								"strip-ansi": "^3.0.1",
+								"wide-align": "^1.1.0"
+							}
+						},
+						"glob": {
+							"version": "7.1.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"fs.realpath": "^1.0.0",
+								"inflight": "^1.0.4",
+								"inherits": "2",
+								"minimatch": "^3.0.4",
+								"once": "^1.3.0",
+								"path-is-absolute": "^1.0.0"
+							}
+						},
+						"has-unicode": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"iconv-lite": {
+							"version": "0.4.24",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safer-buffer": ">= 2.1.2 < 3"
+							}
+						},
+						"ignore-walk": {
+							"version": "3.0.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimatch": "^3.0.4"
+							}
+						},
+						"inflight": {
+							"version": "1.0.6",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"once": "^1.3.0",
+								"wrappy": "1"
+							}
+						},
+						"inherits": {
+							"version": "2.0.4",
+							"bundled": true,
+							"optional": true
+						},
+						"ini": {
+							"version": "1.3.5",
+							"bundled": true,
+							"optional": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"number-is-nan": "^1.0.0"
+							}
+						},
+						"isarray": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"minimatch": {
+							"version": "3.0.4",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"brace-expansion": "^1.1.7"
+							}
+						},
+						"minimist": {
+							"version": "1.2.5",
+							"bundled": true,
+							"optional": true
+						},
+						"minipass": {
+							"version": "2.9.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"minizlib": {
+							"version": "1.3.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minipass": "^2.9.0"
+							}
+						},
+						"mkdirp": {
+							"version": "0.5.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"minimist": "^1.2.5"
+							}
+						},
+						"ms": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"needle": {
+							"version": "2.3.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"debug": "^3.2.6",
+								"iconv-lite": "^0.4.4",
+								"sax": "^1.2.4"
+							}
+						},
+						"node-pre-gyp": {
+							"version": "0.14.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"detect-libc": "^1.0.2",
+								"mkdirp": "^0.5.1",
+								"needle": "^2.2.1",
+								"nopt": "^4.0.1",
+								"npm-packlist": "^1.1.6",
+								"npmlog": "^4.0.2",
+								"rc": "^1.2.7",
+								"rimraf": "^2.6.1",
+								"semver": "^5.3.0",
+								"tar": "^4.4.2"
+							}
+						},
+						"nopt": {
+							"version": "4.0.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"abbrev": "1",
+								"osenv": "^0.1.4"
+							}
+						},
+						"npm-bundled": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						},
+						"npm-normalize-package-bin": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"npm-packlist": {
+							"version": "1.4.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ignore-walk": "^3.0.1",
+								"npm-bundled": "^1.0.1",
+								"npm-normalize-package-bin": "^1.0.1"
+							}
+						},
+						"npmlog": {
+							"version": "4.1.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"are-we-there-yet": "~1.1.2",
+								"console-control-strings": "~1.1.0",
+								"gauge": "~2.7.3",
+								"set-blocking": "~2.0.0"
+							}
+						},
+						"number-is-nan": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"object-assign": {
+							"version": "4.1.1",
+							"bundled": true,
+							"optional": true
+						},
+						"once": {
+							"version": "1.4.0",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"wrappy": "1"
+							}
+						},
+						"os-homedir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"os-tmpdir": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"osenv": {
+							"version": "0.1.5",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"os-homedir": "^1.0.0",
+								"os-tmpdir": "^1.0.0"
+							}
+						},
+						"path-is-absolute": {
+							"version": "1.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"process-nextick-args": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"rc": {
+							"version": "1.2.8",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"deep-extend": "^0.6.0",
+								"ini": "~1.3.0",
+								"minimist": "^1.2.0",
+								"strip-json-comments": "~2.0.1"
+							}
+						},
+						"readable-stream": {
+							"version": "2.3.7",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"rimraf": {
+							"version": "2.7.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"glob": "^7.1.3"
+							}
+						},
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"safer-buffer": {
+							"version": "2.1.2",
+							"bundled": true,
+							"optional": true
+						},
+						"sax": {
+							"version": "1.2.4",
+							"bundled": true,
+							"optional": true
+						},
+						"semver": {
+							"version": "5.7.1",
+							"bundled": true,
+							"optional": true
+						},
+						"set-blocking": {
+							"version": "2.0.0",
+							"bundled": true,
+							"optional": true
+						},
+						"signal-exit": {
+							"version": "3.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"string-width": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"code-point-at": "^1.0.0",
+								"is-fullwidth-code-point": "^1.0.0",
+								"strip-ansi": "^3.0.0"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "3.0.1",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"ansi-regex": "^2.0.0"
+							}
+						},
+						"strip-json-comments": {
+							"version": "2.0.1",
+							"bundled": true,
+							"optional": true
+						},
+						"tar": {
+							"version": "4.4.13",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"chownr": "^1.1.1",
+								"fs-minipass": "^1.2.5",
+								"minipass": "^2.8.6",
+								"minizlib": "^1.2.1",
+								"mkdirp": "^0.5.0",
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.3"
+							}
+						},
+						"util-deprecate": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"wide-align": {
+							"version": "1.1.3",
+							"bundled": true,
+							"optional": true,
+							"requires": {
+								"string-width": "^1.0.2 || 2"
+							}
+						},
+						"wrappy": {
+							"version": "1.0.2",
+							"bundled": true,
+							"optional": true
+						},
+						"yallist": {
+							"version": "3.1.1",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob-parent": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+					"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+					"optional": true,
+					"requires": {
+						"is-glob": "^3.1.0",
+						"path-dirname": "^1.0.0"
+					},
+					"dependencies": {
+						"is-glob": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+							"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+							"optional": true,
+							"requires": {
+								"is-extglob": "^2.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"optional": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"optional": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"optional": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"optional": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -3575,7 +5244,6 @@
 			"version": "0.3.6",
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"define-property": "^0.2.5",
@@ -3587,7 +5255,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -3723,7 +5390,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"dev": true,
 			"requires": {
 				"map-visit": "^1.0.0",
 				"object-visit": "^1.0.0"
@@ -3733,7 +5399,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -3741,8 +5406,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"columnify": {
 			"version": "1.5.4",
@@ -3783,8 +5447,12 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+		},
+		"comment-parser": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.2.tgz",
+			"integrity": "sha512-4Rjb1FnxtOcv9qsfuaNuVsmmVn4ooVoBHzYfyKteiXwIU84PClyGA5jASoFMwPV93+FPh9spwueXauxFJZkGAg=="
 		},
 		"compare-func": {
 			"version": "1.3.2",
@@ -3805,14 +5473,12 @@
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-			"dev": true
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-			"dev": true
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
 			"version": "1.6.2",
@@ -3840,6 +5506,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
+		},
+		"contains-path": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+			"integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
 			"dev": true
 		},
 		"conventional-changelog-angular": {
@@ -4101,8 +5773,7 @@
 		"copy-descriptor": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-			"dev": true
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
 			"version": "2.6.11",
@@ -4110,11 +5781,31 @@
 			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
 			"dev": true
 		},
+		"core-js-compat": {
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.4.tgz",
+			"integrity": "sha512-zAa3IZPvsJ0slViBQ2z+vgyyTuhd3MFn1rBQjZSKVEgB0UMYhUkCj9jJUVPgGTGqWvsBVmfnruXgTcNyTlEiSA==",
+			"requires": {
+				"browserslist": "^4.8.3",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A=="
+				}
+			}
+		},
+		"core-js-pure": {
+			"version": "3.6.4",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+			"integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -4144,6 +5835,16 @@
 					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
 					"dev": true
 				}
+			}
+		},
+		"create-react-class": {
+			"version": "15.6.3",
+			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+			"requires": {
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"cross-spawn": {
@@ -4241,6 +5942,11 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
 			"dev": true
 		},
+		"damerau-levenshtein": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
+			"integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug=="
+		},
 		"dargs": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
@@ -4286,7 +5992,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"dev": true,
 			"requires": {
 				"ms": "^2.1.1"
 			}
@@ -4324,8 +6029,7 @@
 		"decode-uri-component": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-			"dev": true
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
 		},
 		"dedent": {
 			"version": "0.7.0",
@@ -4373,7 +6077,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-			"dev": true,
 			"requires": {
 				"object-keys": "^1.0.12"
 			}
@@ -4382,7 +6085,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"dev": true,
 			"requires": {
 				"is-descriptor": "^1.0.2",
 				"isobject": "^3.0.1"
@@ -4392,7 +6094,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4401,7 +6102,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -4410,7 +6110,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -4570,6 +6269,11 @@
 				"safer-buffer": "^2.1.0"
 			}
 		},
+		"electron-to-chromium": {
+			"version": "1.3.390",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
+			"integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag=="
+		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -4586,7 +6290,6 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
 			"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-			"dev": true,
 			"requires": {
 				"iconv-lite": "~0.4.13"
 			}
@@ -4697,7 +6400,6 @@
 			"version": "1.17.4",
 			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
 			"integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
-			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
@@ -4716,7 +6418,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
 			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-			"dev": true,
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -4741,8 +6442,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.14.1",
@@ -4802,11 +6502,309 @@
 				"v8-compile-cache": "^2.0.3"
 			}
 		},
+		"eslint-config-prettier": {
+			"version": "6.10.1",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+			"integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
+			"requires": {
+				"get-stdin": "^6.0.0"
+			},
+			"dependencies": {
+				"get-stdin": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
+				}
+			}
+		},
+		"eslint-import-resolver-node": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
+			"integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"resolve": "^1.13.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
+		"eslint-module-utils": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz",
+			"integrity": "sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==",
+			"dev": true,
+			"requires": {
+				"debug": "^2.6.9",
+				"pkg-dir": "^2.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.1.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-babel": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz",
+			"integrity": "sha512-HPuNzSPE75O+SnxHIafbW5QB45r2w78fxqwK3HmjqIUoPfPzVrq6rD+CINU3yzoDSzEhUkX07VUphbF73Lth/w==",
+			"requires": {
+				"eslint-rule-composer": "^0.3.0"
+			}
+		},
+		"eslint-plugin-import": {
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
+			"integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
+			"dev": true,
+			"requires": {
+				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.9",
+				"doctrine": "1.5.0",
+				"eslint-import-resolver-node": "^0.3.2",
+				"eslint-module-utils": "^2.4.1",
+				"has": "^1.0.3",
+				"minimatch": "^3.0.4",
+				"object.values": "^1.1.0",
+				"read-pkg-up": "^2.0.0",
+				"resolve": "^1.12.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"doctrine": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
+					}
+				},
+				"load-json-file": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				},
+				"parse-json": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+					"dev": true,
+					"requires": {
+						"error-ex": "^1.2.0"
+					}
+				},
+				"path-type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+					"dev": true,
+					"requires": {
+						"pify": "^2.0.0"
+					}
+				},
+				"pify": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+					"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+					"dev": true,
+					"requires": {
+						"load-json-file": "^2.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^2.0.0"
+					}
+				},
+				"read-pkg-up": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+					"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.0.0",
+						"read-pkg": "^2.0.0"
+					}
+				}
+			}
+		},
+		"eslint-plugin-jest": {
+			"version": "23.8.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.8.2.tgz",
+			"integrity": "sha512-xwbnvOsotSV27MtAe7s8uGWOori0nUsrXh2f1EnpmXua8sDfY6VZhHAhHg2sqK7HBNycRQExF074XSZ7DvfoFg==",
+			"requires": {
+				"@typescript-eslint/experimental-utils": "^2.5.0"
+			}
+		},
+		"eslint-plugin-jsdoc": {
+			"version": "22.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.1.0.tgz",
+			"integrity": "sha512-54NdbICM7KrxsGUqQsev9aIMqPXyvyBx2218Qcm0TQ16P9CtBI+YY4hayJR6adrxlq4Ej0JLpgfUXWaQVFqmQg==",
+			"requires": {
+				"comment-parser": "^0.7.2",
+				"debug": "^4.1.1",
+				"jsdoctypeparser": "^6.1.0",
+				"lodash": "^4.17.15",
+				"regextras": "^0.7.0",
+				"semver": "^6.3.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"eslint-plugin-jsx-a11y": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
+			"integrity": "sha512-CawzfGt9w83tyuVekn0GDPU9ytYtxyxyFZ3aSWROmnRRFQFT2BiPJd7jvRdzNDi6oLWaS2asMeYSNMjWTV4eNg==",
+			"requires": {
+				"@babel/runtime": "^7.4.5",
+				"aria-query": "^3.0.0",
+				"array-includes": "^3.0.3",
+				"ast-types-flow": "^0.0.7",
+				"axobject-query": "^2.0.2",
+				"damerau-levenshtein": "^1.0.4",
+				"emoji-regex": "^7.0.2",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.1"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+				}
+			}
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+			"integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
+			}
+		},
+		"eslint-plugin-react": {
+			"version": "7.19.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
+			"integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
+			"requires": {
+				"array-includes": "^3.1.1",
+				"doctrine": "^2.1.0",
+				"has": "^1.0.3",
+				"jsx-ast-utils": "^2.2.3",
+				"object.entries": "^1.1.1",
+				"object.fromentries": "^2.0.2",
+				"object.values": "^1.1.1",
+				"prop-types": "^15.7.2",
+				"resolve": "^1.15.1",
+				"semver": "^6.3.0",
+				"string.prototype.matchall": "^4.0.2",
+				"xregexp": "^4.3.0"
+			},
+			"dependencies": {
+				"doctrine": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+					"integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				}
+			}
+		},
+		"eslint-plugin-react-hooks": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
+			"integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g=="
+		},
+		"eslint-plugin-vue": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz",
+			"integrity": "sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==",
+			"requires": {
+				"natural-compare": "^1.4.0",
+				"semver": "^5.6.0",
+				"vue-eslint-parser": "^7.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"eslint-rule-composer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+			"integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg=="
+		},
 		"eslint-scope": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
 			"integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-			"dev": true,
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -4824,14 +6822,12 @@
 		"eslint-visitor-keys": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-			"dev": true
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
 		},
 		"espree": {
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
 			"integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
-			"dev": true,
 			"requires": {
 				"acorn": "^7.1.1",
 				"acorn-jsx": "^5.2.0",
@@ -4848,7 +6844,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.1.0.tgz",
 			"integrity": "sha512-MxYW9xKmROWF672KqjO75sszsA8Mxhw06YFeS5VHlB98KDHbOSurm3ArsjO60Eaf3QmGMCP1yn+0JQkNLo/97Q==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.0.0"
 			}
@@ -4857,7 +6852,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
 			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
 			"requires": {
 				"estraverse": "^4.1.0"
 			}
@@ -4865,14 +6859,12 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"eventemitter3": {
 			"version": "3.1.2",
@@ -4911,7 +6903,6 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"dev": true,
 			"requires": {
 				"debug": "^2.3.3",
 				"define-property": "^0.2.5",
@@ -4926,7 +6917,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -4935,7 +6925,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -4944,7 +6933,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -4952,8 +6940,7 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				}
 			}
 		},
@@ -5008,7 +6995,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"dev": true,
 			"requires": {
 				"assign-symbols": "^1.0.0",
 				"is-extendable": "^1.0.1"
@@ -5018,7 +7004,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -5040,7 +7025,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"dev": true,
 			"requires": {
 				"array-unique": "^0.3.2",
 				"define-property": "^1.0.0",
@@ -5056,7 +7040,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -5065,7 +7048,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -5074,7 +7056,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5083,7 +7064,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -5092,7 +7072,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -5112,6 +7091,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
 			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 			"dev": true
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
 		},
 		"fast-glob": {
 			"version": "2.2.7",
@@ -5274,6 +7258,27 @@
 				"bser": "2.1.1"
 			}
 		},
+		"fbjs": {
+			"version": "0.8.17",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+			"integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+			"requires": {
+				"core-js": "^1.0.0",
+				"isomorphic-fetch": "^2.1.1",
+				"loose-envify": "^1.0.0",
+				"object-assign": "^4.1.0",
+				"promise": "^7.1.1",
+				"setimmediate": "^1.0.5",
+				"ua-parser-js": "^0.7.18"
+			},
+			"dependencies": {
+				"core-js": {
+					"version": "1.2.7",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+					"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+				}
+			}
+		},
 		"figgy-pudding": {
 			"version": "3.5.1",
 			"resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -5297,6 +7302,12 @@
 			"requires": {
 				"flat-cache": "^2.0.1"
 			}
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"optional": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -5366,8 +7377,7 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -5390,7 +7400,6 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"dev": true,
 			"requires": {
 				"map-cache": "^0.2.2"
 			}
@@ -5440,8 +7449,7 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-			"dev": true
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
 			"version": "2.1.2",
@@ -5453,8 +7461,7 @@
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-			"dev": true
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
 			"version": "1.1.2",
@@ -5773,8 +7780,7 @@
 		"get-value": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-			"dev": true
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -5877,7 +7883,6 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5953,8 +7958,7 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -6001,7 +8005,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dev": true,
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
@@ -6026,14 +8029,12 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-			"dev": true
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"has-unicode": {
 			"version": "2.0.1",
@@ -6045,7 +8046,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"dev": true,
 			"requires": {
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
@@ -6056,7 +8056,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"dev": true,
 			"requires": {
 				"is-number": "^3.0.0",
 				"kind-of": "^4.0.0"
@@ -6066,7 +8065,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "^3.0.2"
 					},
@@ -6075,7 +8073,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "^1.1.5"
 							}
@@ -6086,7 +8083,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6335,7 +8331,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -6420,7 +8415,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6429,8 +8423,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -6544,6 +8537,24 @@
 				}
 			}
 		},
+		"internal-slot": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
+			"integrity": "sha512-2cQNfwhAfJIkU4KZPkDI+Gj5yNNnbqi40W9Gge6dfnk4TocEVm00B3bdiL+JINrbGJil2TeHvM4rETGzk/f/0g==",
+			"requires": {
+				"es-abstract": "^1.17.0-next.1",
+				"has": "^1.0.3",
+				"side-channel": "^1.0.2"
+			}
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
 		"ip": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -6560,7 +8571,6 @@
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6569,7 +8579,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6582,6 +8591,15 @@
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
 			"dev": true
 		},
+		"is-binary-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+			"optional": true,
+			"requires": {
+				"binary-extensions": "^1.0.0"
+			}
+		},
 		"is-boolean-object": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
@@ -6591,14 +8609,12 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
-			"dev": true
+			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
 		},
 		"is-ci": {
 			"version": "2.0.0",
@@ -6613,7 +8629,6 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -6622,7 +8637,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -6632,14 +8646,12 @@
 		"is-date-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-			"dev": true
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"dev": true,
 			"requires": {
 				"is-accessor-descriptor": "^0.1.6",
 				"is-data-descriptor": "^0.1.4",
@@ -6649,8 +8661,7 @@
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				}
 			}
 		},
@@ -6663,14 +8674,12 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.1.0",
@@ -6694,7 +8703,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -6736,7 +8744,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -6751,7 +8758,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
 			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
 			}
@@ -6774,14 +8780,12 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-string": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-			"dev": true
+			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
 		},
 		"is-subset": {
 			"version": "0.1.1",
@@ -6793,7 +8797,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.1"
 			}
@@ -6822,8 +8825,7 @@
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"dev": true
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
 		},
 		"is-wsl": {
 			"version": "2.1.1",
@@ -6835,8 +8837,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -6847,8 +8848,27 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isomorphic-fetch": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+			"requires": {
+				"node-fetch": "^1.0.1",
+				"whatwg-fetch": ">=0.10.0"
+			},
+			"dependencies": {
+				"node-fetch": {
+					"version": "1.7.3",
+					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+					"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+					"requires": {
+						"encoding": "^0.1.11",
+						"is-stream": "^1.0.1"
+					}
+				}
+			}
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -8201,8 +10221,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.13.1",
@@ -8219,6 +10238,11 @@
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"dev": true
+		},
+		"jsdoctypeparser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-6.1.0.tgz",
+			"integrity": "sha512-UCQBZ3xCUBv/PLfwKAJhp6jmGOSLFNKzrotXGNgbKhWvz27wPsCsVeP7gIcHPElQw2agBmynAitXqhxR58XAmA=="
 		},
 		"jsdom": {
 			"version": "15.2.1",
@@ -8257,8 +10281,7 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -8326,11 +10349,19 @@
 				"verror": "1.10.0"
 			}
 		},
+		"jsx-ast-utils": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz",
+			"integrity": "sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==",
+			"requires": {
+				"array-includes": "^3.0.3",
+				"object.assign": "^4.1.0"
+			}
+		},
 		"kind-of": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"dev": true
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
 		},
 		"kleur": {
 			"version": "3.0.3",
@@ -8446,8 +10477,15 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
+		},
+		"levenary": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.1.tgz",
+			"integrity": "sha512-mkAdOIt79FD6irqjYSs4rdbnlT5vRonMEvBVPVb3XmevfS8kgRXwfes0dhPdEtzTWD/1eNE/Bm/G1iRt6DcnQQ==",
+			"requires": {
+				"leven": "^3.1.0"
+			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -8846,8 +10884,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash._baseisequal": {
 			"version": "3.0.7",
@@ -9098,6 +11135,14 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
 		"loud-rejection": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -9163,8 +11208,7 @@
 		"map-cache": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-			"dev": true
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
 		},
 		"map-obj": {
 			"version": "2.0.0",
@@ -9176,7 +11220,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"dev": true,
 			"requires": {
 				"object-visit": "^1.0.0"
 			}
@@ -9257,7 +11300,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -9331,7 +11373,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
 			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -9341,7 +11382,6 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"dev": true,
 					"requires": {
 						"is-plain-object": "^2.0.4"
 					}
@@ -9395,8 +11435,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"multimatch": {
 			"version": "3.0.0",
@@ -9427,11 +11466,16 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
+		"nan": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+			"optional": true
+		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"dev": true,
 			"requires": {
 				"arr-diff": "^4.0.0",
 				"array-unique": "^0.3.2",
@@ -9449,8 +11493,7 @@
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-			"dev": true
+			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
 		},
 		"nearley": {
 			"version": "2.19.1",
@@ -9555,6 +11598,11 @@
 				"which": "^1.3.1"
 			}
 		},
+		"node-releases": {
+			"version": "1.1.53",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+			"integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
+		},
 		"nopt": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
@@ -9588,8 +11636,7 @@
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-			"dev": true
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
 		},
 		"normalize-url": {
 			"version": "3.3.0",
@@ -9737,14 +11784,12 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"dev": true,
 			"requires": {
 				"copy-descriptor": "^0.1.0",
 				"define-property": "^0.2.5",
@@ -9755,7 +11800,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -9764,7 +11808,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -9774,8 +11817,7 @@
 		"object-inspect": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-			"dev": true
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 		},
 		"object-is": {
 			"version": "1.0.2",
@@ -9786,14 +11828,12 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
 			}
@@ -9802,7 +11842,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
 			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.2",
 				"function-bind": "^1.1.1",
@@ -9814,7 +11853,17 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
 			"integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
-			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3"
+			}
+		},
+		"object.fromentries": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+			"integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
@@ -9836,7 +11885,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -9845,7 +11893,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
 			"integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.17.0-next.1",
@@ -9863,7 +11910,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -10095,26 +12141,22 @@
 		"pascalcase": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-			"dev": true
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
 		},
 		"path-dirname": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-			"dev": true
+			"integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
 		},
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"dev": true
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
 		},
 		"path-key": {
 			"version": "2.0.1",
@@ -10125,8 +12167,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -10239,6 +12280,54 @@
 				}
 			}
 		},
+		"pkg-up": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+			"integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+			"requires": {
+				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				}
+			}
+		},
 		"please-upgrade-node": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -10257,14 +12346,26 @@
 		"posix-character-classes": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-			"dev": true
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
 			"dev": true
+		},
+		"prettier": {
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
 		},
 		"pretty-format": {
 			"version": "25.1.0",
@@ -10305,17 +12406,29 @@
 				}
 			}
 		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+		},
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
 			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
 			"dev": true
+		},
+		"promise": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+			"requires": {
+				"asap": "~2.0.3"
+			}
 		},
 		"promise-inflight": {
 			"version": "1.0.1",
@@ -10350,6 +12463,16 @@
 			"dev": true,
 			"requires": {
 				"read": "1"
+			}
+		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
 			}
 		},
 		"proto-list": {
@@ -10461,11 +12584,20 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"react": {
+			"version": "16.13.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+			"integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"read": {
 			"version": "1.0.7",
@@ -10534,7 +12666,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -10557,6 +12688,122 @@
 				"once": "^1.3.0"
 			}
 		},
+		"readdirp": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+			"integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.11",
+				"micromatch": "^3.1.10",
+				"readable-stream": "^2.0.2"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"optional": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"optional": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"optional": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"optional": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"optional": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"optional": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"optional": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"realpath-native": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -10576,20 +12823,50 @@
 				"strip-indent": "^2.0.0"
 			}
 		},
+		"regenerate": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+		},
+		"regenerate-unicode-properties": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
+			"requires": {
+				"regenerate": "^1.4.0"
+			}
+		},
 		"regenerator-runtime": {
 			"version": "0.11.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
 			"integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
 			"dev": true
 		},
+		"regenerator-transform": {
+			"version": "0.14.4",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+			"integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
+			"requires": {
+				"@babel/runtime": "^7.8.4",
+				"private": "^0.1.8"
+			}
+		},
 		"regex-not": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.2",
 				"safe-regex": "^1.1.0"
+			}
+		},
+		"regexp.prototype.flags": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"regexpp": {
@@ -10598,23 +12875,58 @@
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 			"dev": true
 		},
+		"regexpu-core": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+			"integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+			"requires": {
+				"regenerate": "^1.4.0",
+				"regenerate-unicode-properties": "^8.2.0",
+				"regjsgen": "^0.5.1",
+				"regjsparser": "^0.6.4",
+				"unicode-match-property-ecmascript": "^1.0.4",
+				"unicode-match-property-value-ecmascript": "^1.2.0"
+			}
+		},
+		"regextras": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.0.tgz",
+			"integrity": "sha512-ds+fL+Vhl918gbAUb0k2gVKbTZLsg84Re3DI6p85Et0U0tYME3hyW4nMK8Px4dtDaBA2qNjvG5uWyW7eK5gfmw=="
+		},
+		"regjsgen": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
+			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
+		},
+		"regjsparser": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
+			"requires": {
+				"jsesc": "~0.5.0"
+			},
+			"dependencies": {
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+				}
+			}
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"dev": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-			"dev": true
+			"integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -10709,11 +13021,15 @@
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
 		},
+		"require-package-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+			"integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk="
+		},
 		"resolve": {
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
 			"integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -10745,8 +13061,7 @@
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-			"dev": true
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
 		},
 		"restore-cursor": {
 			"version": "3.1.0",
@@ -10761,8 +13076,7 @@
 		"ret": {
 			"version": "0.1.15",
 			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"dev": true
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
 		},
 		"retry": {
 			"version": "0.10.1",
@@ -10825,14 +13139,12 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"dev": true,
 			"requires": {
 				"ret": "~0.1.10"
 			}
@@ -10840,8 +13152,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
 			"version": "4.1.0",
@@ -10996,8 +13307,7 @@
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -11021,7 +13331,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
 			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -11033,12 +13342,16 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
 				}
 			}
+		},
+		"setimmediate": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+			"integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
 		},
 		"shallow-clone": {
 			"version": "3.0.1",
@@ -11070,6 +13383,15 @@
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true,
 			"optional": true
+		},
+		"side-channel": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
+			"integrity": "sha512-7rL9YlPHg7Ancea1S96Pa8/QWb4BtXL/TZvS6B8XFetGBeuhAsfmUspK6DokBeZ64+Kj9TCNRD/30pVz1BvQNA==",
+			"requires": {
+				"es-abstract": "^1.17.0-next.1",
+				"object-inspect": "^1.7.0"
+			}
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -11124,7 +13446,6 @@
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"dev": true,
 			"requires": {
 				"base": "^0.11.1",
 				"debug": "^2.2.0",
@@ -11140,7 +13461,6 @@
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
@@ -11149,7 +13469,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11158,7 +13477,6 @@
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
 					}
@@ -11166,14 +13484,12 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-					"dev": true
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 				}
 			}
 		},
@@ -11181,7 +13497,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^1.0.0",
 				"isobject": "^3.0.0",
@@ -11192,7 +13507,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^1.0.0"
 					}
@@ -11201,7 +13515,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -11210,7 +13523,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"dev": true,
 					"requires": {
 						"kind-of": "^6.0.0"
 					}
@@ -11219,7 +13531,6 @@
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"dev": true,
 					"requires": {
 						"is-accessor-descriptor": "^1.0.0",
 						"is-data-descriptor": "^1.0.0",
@@ -11232,7 +13543,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.2.0"
 			},
@@ -11241,7 +13551,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -11298,7 +13607,6 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
 			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-			"dev": true,
 			"requires": {
 				"atob": "^2.1.2",
 				"decode-uri-component": "^0.2.0",
@@ -11320,8 +13628,7 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"spdx-correct": {
 			"version": "3.1.0",
@@ -11336,14 +13643,12 @@
 		"spdx-exceptions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-			"dev": true
+			"integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
 		},
 		"spdx-expression-parse": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"dev": true,
 			"requires": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
@@ -11352,8 +13657,7 @@
 		"spdx-license-ids": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-			"dev": true
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"split": {
 			"version": "1.0.1",
@@ -11368,7 +13672,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
 			}
@@ -11436,7 +13739,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"dev": true,
 			"requires": {
 				"define-property": "^0.2.5",
 				"object-copy": "^0.1.0"
@@ -11446,7 +13748,6 @@
 					"version": "0.2.5",
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"dev": true,
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
@@ -11513,6 +13814,19 @@
 				}
 			}
 		},
+		"string.prototype.matchall": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
+			"integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0",
+				"has-symbols": "^1.0.1",
+				"internal-slot": "^1.0.2",
+				"regexp.prototype.flags": "^1.3.0",
+				"side-channel": "^1.0.2"
+			}
+		},
 		"string.prototype.trim": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
@@ -11528,7 +13842,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
 			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -11538,7 +13851,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
 			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
-			"dev": true,
 			"requires": {
 				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1"
@@ -11548,7 +13860,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -11626,7 +13937,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -11843,14 +14153,12 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			},
@@ -11859,7 +14167,6 @@
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -11870,7 +14177,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"dev": true,
 			"requires": {
 				"define-property": "^2.0.2",
 				"extend-shallow": "^3.0.2",
@@ -11922,8 +14228,15 @@
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
-			"dev": true
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+		},
+		"tsutils": {
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+			"requires": {
+				"tslib": "^1.8.1"
+			}
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -11976,6 +14289,11 @@
 				"is-typedarray": "^1.0.0"
 			}
 		},
+		"ua-parser-js": {
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+		},
 		"uglify-js": {
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
@@ -11999,11 +14317,34 @@
 			"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 			"dev": true
 		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ=="
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+		},
 		"union-value": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
 			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
@@ -12048,7 +14389,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"dev": true,
 			"requires": {
 				"has-value": "^0.3.1",
 				"isobject": "^3.0.0"
@@ -12058,7 +14398,6 @@
 					"version": "0.3.1",
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"dev": true,
 					"requires": {
 						"get-value": "^2.0.3",
 						"has-values": "^0.1.4",
@@ -12069,7 +14408,6 @@
 							"version": "2.1.0",
 							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"dev": true,
 							"requires": {
 								"isarray": "1.0.0"
 							}
@@ -12079,16 +14417,14 @@
 				"has-values": {
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
 				}
 			}
 		},
 		"upath": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-			"dev": true
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
 		},
 		"uri-js": {
 			"version": "4.2.2",
@@ -12102,20 +14438,17 @@
 		"urix": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-			"dev": true
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
 		},
 		"use": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"dev": true
+			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util-promisify": {
 			"version": "2.1.0",
@@ -12199,6 +14532,19 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
+		"vue-eslint-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
+			"integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
+			"requires": {
+				"debug": "^4.1.1",
+				"eslint-scope": "^5.0.0",
+				"eslint-visitor-keys": "^1.1.0",
+				"espree": "^6.1.2",
+				"esquery": "^1.0.1",
+				"lodash": "^4.17.15"
+			}
+		},
 		"w3c-hr-time": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -12251,6 +14597,11 @@
 			"requires": {
 				"iconv-lite": "0.4.24"
 			}
+		},
+		"whatwg-fetch": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+			"integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
 		},
 		"whatwg-mimetype": {
 			"version": "2.3.0",
@@ -12403,8 +14754,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -12539,6 +14889,14 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true
+		},
+		"xregexp": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+			"integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+			"requires": {
+				"@babel/runtime-corejs3": "^7.8.3"
+			}
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@commitlint/config-conventional": "^8.2.0",
     "@moxy/jest-config": "^2.1.0",
     "eslint": "^6.8.0",
+    "eslint-plugin-import": "^2.20.1",
     "husky": "^4.2.3",
     "jest": "^25.1.0",
     "lerna": "^3.20.2",

--- a/packages/eslint-config-base/lib/modules/esm.js
+++ b/packages/eslint-config-base/lib/modules/esm.js
@@ -9,5 +9,13 @@ module.exports = {
         'import/no-amd': 'error',
         // Report CommonJS require calls and module.exports or exports.*
         'import/no-commonjs': ['error', { allowConditionalRequire: false }],
+        // Order imports
+        'import/order': ['error', {
+            groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        }],
+        // Imports should be at top of the module
+        'import/first': 'error',
+        // Last import sould have a newline after
+        'import/newline-after-import': ['error', { count: 1 }],
     },
 };

--- a/packages/eslint-config-base/test/samples/es2015-esm/contrived.bad.js
+++ b/packages/eslint-config-base/test/samples/es2015-esm/contrived.bad.js
@@ -15,6 +15,7 @@ fs.read(foo);
 foobar();
 baz();
 barbaz();
+index();
 
 // Test warning when using require
 
@@ -24,3 +25,4 @@ const bar = require('foo/bar');
 import biz from '../biz';
 
 bar();
+biz();

--- a/packages/eslint-config-base/test/samples/es2015-esm/contrived.bad.js
+++ b/packages/eslint-config-base/test/samples/es2015-esm/contrived.bad.js
@@ -1,11 +1,26 @@
 // Made up sample.. not genuine
-
 // Test unnecessary `use strict`
 
 'use strict';
 
+// Test imports with different groups and order
+import fs from 'fs';
+import index from './';
+import foobar from '../../foobar';
+import foo from 'foo';
+import barbaz from './bar/baz';
+import baz from '../baz';
+fs.read(foo);
+
+foobar();
+baz();
+barbaz();
+
 // Test warning when using require
 
 const bar = require('foo/bar');
+
+// Test imports in body of module
+import biz from '../biz';
 
 bar();

--- a/packages/eslint-config-base/test/samples/es2015-esm/contrived.good.js
+++ b/packages/eslint-config-base/test/samples/es2015-esm/contrived.good.js
@@ -1,9 +1,19 @@
 // Made up sample.. not genuine
 
 import fs from 'fs';
+import foo from 'foo';
+import foobar from '../../foobar';
+import baz from '../baz';
+import bar from './bar/baz';
+import index from './';
 
 fs.readFileSync('/path/to/file');
 
-import bar from 'foo/bar';
+foo();
+
+foobar();
+baz();
 
 bar();
+
+index();

--- a/packages/eslint-config-vue/test/rules/vue-no-shared-component-data.vue
+++ b/packages/eslint-config-vue/test/rules/vue-no-shared-component-data.vue
@@ -3,6 +3,7 @@
 <script>
 /* ✗ BAD */
 import Vue from "vue";
+
 Vue.component("some-comp", {
     data: {
         foo: "bar"


### PR DESCRIPTION
In light of this [RFC](https://github.com/moxystudio/rfcs-oss/blob/master/rfcs/0004-eslint-config-import.md) two rules were added to our config: 

- `import/order`: displays an error when imports are not in the following order: `builtin`, `external`, `parent`, `sibling`, `index` and groups are not separated with a new line.

- `import/first`: displays an error when imports are made in the module's body.

As for `import/first`, since we already happen to have `import/order`, which already orders the module's import, this could be turned off in certain cases but maybe it's best to ensure all imports are made at the top of the file.

