### PR TITLE
fix: add files in __mocks__ to test patterns

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1495,6 +1495,8 @@ Array [
 ]
 `;
 
+exports[`should pass on packages/eslint-config-jest/test/samples/project-cjs/__mocks__/sample-mock.js 1`] = `Array []`;
+
 exports[`should pass on packages/eslint-config-jest/test/samples/project-cjs/__tests__/non-test-file.js 1`] = `
 Array [
   Object {
@@ -1648,6 +1650,8 @@ Array [
 exports[`should pass on packages/eslint-config-jest/test/samples/project-cjs/tests/test.js 1`] = `Array []`;
 
 exports[`should pass on packages/eslint-config-jest/test/samples/project-cjs/tests/test-file.test.js 1`] = `Array []`;
+
+exports[`should pass on packages/eslint-config-jest/test/samples/project-esm/__mocks__/sample-mock.js 1`] = `Array []`;
 
 exports[`should pass on packages/eslint-config-jest/test/samples/project-esm/__tests__/non-test-file.js 1`] = `
 Array [

--- a/packages/eslint-config-base/lib/test-patterns.js
+++ b/packages/eslint-config-base/lib/test-patterns.js
@@ -2,4 +2,5 @@
 
 module.exports = [
     '**/?(*.)test.[jt]s',
+    '__mocks__/**/*.js',
 ];

--- a/packages/eslint-config-jest/test/samples/project-cjs/__mocks__/sample-mock.js
+++ b/packages/eslint-config-jest/test/samples/project-cjs/__mocks__/sample-mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    foo: jest.fn(),
+};

--- a/packages/eslint-config-jest/test/samples/project-esm/__mocks__/sample-mock.js
+++ b/packages/eslint-config-jest/test/samples/project-esm/__mocks__/sample-mock.js
@@ -1,0 +1,3 @@
+export default {
+    foo: jest.fn(),
+};


### PR DESCRIPTION
Considers files present in the `__mocks__` directory in the `test-patterns.js`. This prevents `no-undef` ESlint errors for usage of the `jest`global inside global mocks.

Added relevant test files.

Fixes #93. 