### PR TITLE
fix(eslint-config-base): update eslint peer dependency due to modification in no-implicit-gloabls rule

### DIFF
--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-jsdoc": "^22.1.0"
   },
   "peerDependencies": {
-    "eslint": "^6.0.0"
+    "eslint": "^6.7.0"
   },
   "engines": {
     "node": ">=10",


### PR DESCRIPTION
In our best practices rule file, we have the `no-implicit-globals` rule with an extra option `lexicalBindings` set to `true`. This extra option was only added in Eslint v6.7.0. Currently, the peer dependency is `^6.0.0` which will not produce a warning if a user install any version higher than `6.0.0` and lower than `6.7.0`. Without version `6.7.0` a rule configuration error will be thrown regarding the option `lexicalBindings`. This MR simply updates the peer dependency of eslint so the user can have a warning and update it if this error appears.
