### PR TITLE
Add project URLs to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "root",
   "private": true,
+  "homepage": "https://github.com/moxystudio/eslint-config",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:moxystudio/eslint-config.git"
+  },
   "scripts": {
     "lint": "eslint . --ignore-pattern **/test",
     "test": "jest",


### PR DESCRIPTION
After #100 is merged this will become necessary, otherwise URLs which allow to compare the differences between two tags will be broken in the root `CHANGELOG.md` after running `lerna publish` with `conventionalcommits` preset.