### PR TITLE
feat: add lowercase-name rule

### DIFF
--- a/__snapshots__/index.test.js.snap
+++ b/__snapshots__/index.test.js.snap
@@ -1527,6 +1527,18 @@ Array [
     "rule": "no-undef",
     "severity": 2,
   },
+  Object {
+    "column": 1,
+    "line": 51,
+    "rule": "no-undef",
+    "severity": 2,
+  },
+  Object {
+    "column": 1,
+    "line": 53,
+    "rule": "no-undef",
+    "severity": 2,
+  },
 ]
 `;
 

--- a/packages/eslint-config-jest/lib/rules/jest.js
+++ b/packages/eslint-config-jest/lib/rules/jest.js
@@ -14,5 +14,7 @@ module.exports = {
         'jest/prefer-to-have-length': 'error',
         // Ensure expect is called correctly
         'jest/valid-expect': 'error',
+        // Enforce lowercase test names
+        'jest/lowercase-name': 'error',
     },
 };

--- a/packages/eslint-config-jest/test/rules/jest.spec.js
+++ b/packages/eslint-config-jest/test/rules/jest.spec.js
@@ -44,3 +44,10 @@ it('valid-expect bad', () => {
 it('valid-expect good', () => {
     expect('something').not.toEqual('else');
 });
+
+// `lowercase-name` - Enforce lowercase test names
+// ---------------------------------------------------------------------
+// Bad
+it('Lowercase-name bad', () => {});
+// Good
+it('lowercase-name good', () => {});


### PR DESCRIPTION
Resolves https://github.com/moxystudio/eslint-config/issues/106

Adds [`lowercase-name`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/lowercase-name.md) rule to our Jest ESLint config. This rule makes it so test names must begin with a lowercase letter.

```js
// Bad 
it('Bad test name', () => {});
// Good
it('good test name', () => {});
```